### PR TITLE
Add JDBC-based storage implementations

### DIFF
--- a/src/main/java/ru/yandex/practicum/filmorate/service/FilmService.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/service/FilmService.java
@@ -1,6 +1,7 @@
 package ru.yandex.practicum.filmorate.service;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 import ru.yandex.practicum.filmorate.exception.NotFoundException;
 import ru.yandex.practicum.filmorate.model.Film;
@@ -17,7 +18,8 @@ public class FilmService {
     private final UserStorage userStorage;
 
     @Autowired
-    public FilmService(FilmStorage filmStorage, UserStorage userStorage) {
+    public FilmService(@Qualifier("inMemoryFilmStorage") FilmStorage filmStorage,
+                       @Qualifier("inMemoryUserStorage") UserStorage userStorage) {
         this.filmStorage = filmStorage;
         this.userStorage = userStorage;
     }

--- a/src/main/java/ru/yandex/practicum/filmorate/service/UserService.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/service/UserService.java
@@ -1,6 +1,7 @@
 package ru.yandex.practicum.filmorate.service;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 import ru.yandex.practicum.filmorate.model.User;
 import ru.yandex.practicum.filmorate.storage.user.UserStorage;
@@ -15,7 +16,7 @@ public class UserService {
     private final UserStorage userStorage;
 
     @Autowired
-    public UserService(UserStorage userStorage) {
+    public UserService(@Qualifier("inMemoryUserStorage") UserStorage userStorage) {
         this.userStorage = userStorage;
     }
 

--- a/src/main/java/ru/yandex/practicum/filmorate/storage/film/FilmDbStorage.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/storage/film/FilmDbStorage.java
@@ -1,0 +1,219 @@
+package ru.yandex.practicum.filmorate.storage.film;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.simple.SimpleJdbcInsert;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+import ru.yandex.practicum.filmorate.exception.NotFoundException;
+import ru.yandex.practicum.filmorate.model.Film;
+import ru.yandex.practicum.filmorate.model.Genre;
+import ru.yandex.practicum.filmorate.model.MpaRating;
+
+import java.sql.Date;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Repository
+@Qualifier("filmDbStorage")
+public class FilmDbStorage implements FilmStorage {
+    private final JdbcTemplate jdbcTemplate;
+    private final RowMapper<Film> filmRowMapper = this::mapRowToFilm;
+
+    public FilmDbStorage(JdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    @Override
+    @Transactional
+    public Film create(Film film) {
+        SimpleJdbcInsert insert = new SimpleJdbcInsert(jdbcTemplate)
+                .withTableName("films")
+                .usingGeneratedKeyColumns("film_id");
+
+        Map<String, Object> values = new HashMap<>();
+        values.put("name", film.getName());
+        values.put("description", film.getDescription());
+        values.put("release_date", toSqlDate(film.getReleaseDate()));
+        values.put("duration", film.getDuration());
+        values.put("mpa_rating_id", film.getMpa() != null ? film.getMpa().getId() : null);
+
+        Number id = insert.executeAndReturnKey(values);
+        film.setId(Objects.requireNonNull(id).longValue());
+
+        updateGenres(film);
+        updateLikes(film);
+        return findById(film.getId());
+    }
+
+    @Override
+    @Transactional
+    public Film update(Film film) {
+        int updated = jdbcTemplate.update(
+                "UPDATE films SET name = ?, description = ?, release_date = ?, duration = ?, mpa_rating_id = ? WHERE film_id = ?",
+                film.getName(),
+                film.getDescription(),
+                toSqlDate(film.getReleaseDate()),
+                film.getDuration(),
+                film.getMpa() != null ? film.getMpa().getId() : null,
+                film.getId()
+        );
+
+        if (updated == 0) {
+            throw new NotFoundException("Film not found");
+        }
+
+        updateGenres(film);
+        updateLikes(film);
+        return findById(film.getId());
+    }
+
+    @Override
+    public Collection<Film> findAll() {
+        List<Film> films = jdbcTemplate.query(
+                "SELECT f.film_id, f.name, f.description, f.release_date, f.duration, f.mpa_rating_id, m.name AS mpa_name " +
+                        "FROM films f JOIN mpa_ratings m ON f.mpa_rating_id = m.mpa_rating_id",
+                filmRowMapper
+        );
+
+        populateGenresAndLikes(films);
+        return films;
+    }
+
+    @Override
+    public Film findById(Long id) {
+        List<Film> films = jdbcTemplate.query(
+                "SELECT f.film_id, f.name, f.description, f.release_date, f.duration, f.mpa_rating_id, m.name AS mpa_name " +
+                        "FROM films f JOIN mpa_ratings m ON f.mpa_rating_id = m.mpa_rating_id WHERE f.film_id = ?",
+                filmRowMapper,
+                id
+        );
+
+        if (films.isEmpty()) {
+            throw new NotFoundException("Film not found");
+        }
+
+        Film film = films.get(0);
+        populateGenresAndLikes(List.of(film));
+        return film;
+    }
+
+    @Override
+    @Transactional
+    public void delete(Long id) {
+        jdbcTemplate.update("DELETE FROM films WHERE film_id = ?", id);
+    }
+
+    private Film mapRowToFilm(ResultSet rs, int rowNum) throws SQLException {
+        Film film = new Film();
+        film.setId(rs.getLong("film_id"));
+        film.setName(rs.getString("name"));
+        film.setDescription(rs.getString("description"));
+        Date releaseDate = rs.getDate("release_date");
+        if (releaseDate != null) {
+            film.setReleaseDate(releaseDate.toLocalDate());
+        }
+        film.setDuration(rs.getInt("duration"));
+        int mpaId = rs.getInt("mpa_rating_id");
+        String mpaName = rs.getString("mpa_name");
+        film.setMpa(new MpaRating(mpaId, mpaName));
+        return film;
+    }
+
+    private void populateGenresAndLikes(Collection<Film> films) {
+        if (films.isEmpty()) {
+            return;
+        }
+
+        Map<Long, Film> filmsById = films.stream()
+                .collect(Collectors.toMap(Film::getId, Function.identity(), (left, right) -> left, LinkedHashMap::new));
+
+        films.forEach(film -> {
+            film.getGenres().clear();
+            film.getLikes().clear();
+        });
+
+        List<Long> ids = new ArrayList<>(filmsById.keySet());
+        String placeholders = ids.stream()
+                .map(id -> "?")
+                .collect(Collectors.joining(","));
+
+        jdbcTemplate.query(
+                "SELECT fg.film_id, g.genre_id, g.name FROM film_genres fg " +
+                        "JOIN genres g ON fg.genre_id = g.genre_id WHERE fg.film_id IN (" + placeholders + ") " +
+                        "ORDER BY fg.film_id, g.genre_id",
+                ids.toArray(),
+                rs -> {
+                    long filmId = rs.getLong("film_id");
+                    Film film = filmsById.get(filmId);
+                    if (film != null) {
+                        film.getGenres().add(new Genre(rs.getInt("genre_id"), rs.getString("name")));
+                    }
+                }
+        );
+
+        jdbcTemplate.query(
+                "SELECT film_id, user_id FROM film_likes WHERE film_id IN (" + placeholders + ")",
+                ids.toArray(),
+                rs -> {
+                    long filmId = rs.getLong("film_id");
+                    Film film = filmsById.get(filmId);
+                    if (film != null) {
+                        film.getLikes().add(rs.getLong("user_id"));
+                    }
+                }
+        );
+    }
+
+    private void updateGenres(Film film) {
+        jdbcTemplate.update("DELETE FROM film_genres WHERE film_id = ?", film.getId());
+
+        Set<Genre> genres = film.getGenres();
+        if (genres == null || genres.isEmpty()) {
+            return;
+        }
+
+        List<Object[]> batchArgs = genres.stream()
+                .map(genre -> new Object[]{film.getId(), genre.getId()})
+                .toList();
+
+        jdbcTemplate.batchUpdate(
+                "INSERT INTO film_genres (film_id, genre_id) VALUES (?, ?)",
+                batchArgs
+        );
+    }
+
+    private void updateLikes(Film film) {
+        jdbcTemplate.update("DELETE FROM film_likes WHERE film_id = ?", film.getId());
+
+        Set<Long> likes = film.getLikes();
+        if (likes == null || likes.isEmpty()) {
+            return;
+        }
+
+        List<Object[]> batchArgs = likes.stream()
+                .map(userId -> new Object[]{film.getId(), userId})
+                .toList();
+
+        jdbcTemplate.batchUpdate(
+                "INSERT INTO film_likes (film_id, user_id) VALUES (?, ?)",
+                batchArgs
+        );
+    }
+
+    private Date toSqlDate(LocalDate date) {
+        return date == null ? null : Date.valueOf(date);
+    }
+}

--- a/src/main/java/ru/yandex/practicum/filmorate/storage/film/InMemoryFilmStorage.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/storage/film/InMemoryFilmStorage.java
@@ -1,5 +1,6 @@
 package ru.yandex.practicum.filmorate.storage.film;
 
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 import ru.yandex.practicum.filmorate.exception.NotFoundException;
 import ru.yandex.practicum.filmorate.model.Film;
@@ -9,6 +10,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 @Component
+@Qualifier("inMemoryFilmStorage")
 public class InMemoryFilmStorage implements FilmStorage {
     private final Map<Long, Film> films = new HashMap<>();
     private long nextId = 1;

--- a/src/main/java/ru/yandex/practicum/filmorate/storage/user/InMemoryUserStorage.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/storage/user/InMemoryUserStorage.java
@@ -1,5 +1,6 @@
 package ru.yandex.practicum.filmorate.storage.user;
 
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 import ru.yandex.practicum.filmorate.exception.NotFoundException;
 import ru.yandex.practicum.filmorate.model.User;
@@ -9,6 +10,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 @Component
+@Qualifier("inMemoryUserStorage")
 public class InMemoryUserStorage implements UserStorage {
     private final Map<Long, User> users = new HashMap<>();
     private long nextId = 1;

--- a/src/main/java/ru/yandex/practicum/filmorate/storage/user/UserDbStorage.java
+++ b/src/main/java/ru/yandex/practicum/filmorate/storage/user/UserDbStorage.java
@@ -1,0 +1,173 @@
+package ru.yandex.practicum.filmorate.storage.user;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.simple.SimpleJdbcInsert;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+import ru.yandex.practicum.filmorate.exception.NotFoundException;
+import ru.yandex.practicum.filmorate.model.User;
+
+import java.sql.Date;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.LocalDate;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Repository
+@Qualifier("userDbStorage")
+public class UserDbStorage implements UserStorage {
+    private final JdbcTemplate jdbcTemplate;
+    private final RowMapper<User> userRowMapper = this::mapRowToUser;
+
+    public UserDbStorage(JdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    @Override
+    @Transactional
+    public User create(User user) {
+        SimpleJdbcInsert insert = new SimpleJdbcInsert(jdbcTemplate)
+                .withTableName("users")
+                .usingGeneratedKeyColumns("user_id");
+
+        Map<String, Object> values = new HashMap<>();
+        values.put("email", user.getEmail());
+        values.put("login", user.getLogin());
+        values.put("name", user.getName());
+        values.put("birthday", toSqlDate(user.getBirthday()));
+
+        Number id = insert.executeAndReturnKey(values);
+        user.setId(Objects.requireNonNull(id).longValue());
+
+        updateFriendships(user);
+        return findById(user.getId());
+    }
+
+    @Override
+    @Transactional
+    public User update(User user) {
+        int updated = jdbcTemplate.update(
+                "UPDATE users SET email = ?, login = ?, name = ?, birthday = ? WHERE user_id = ?",
+                user.getEmail(),
+                user.getLogin(),
+                user.getName(),
+                toSqlDate(user.getBirthday()),
+                user.getId()
+        );
+
+        if (updated == 0) {
+            throw new NotFoundException("User not found");
+        }
+
+        updateFriendships(user);
+        return findById(user.getId());
+    }
+
+    @Override
+    public Collection<User> findAll() {
+        List<User> users = jdbcTemplate.query(
+                "SELECT user_id, email, login, name, birthday FROM users",
+                userRowMapper
+        );
+
+        populateFriendships(users);
+        return users;
+    }
+
+    @Override
+    public User findById(Long id) {
+        List<User> users = jdbcTemplate.query(
+                "SELECT user_id, email, login, name, birthday FROM users WHERE user_id = ?",
+                userRowMapper,
+                id
+        );
+
+        if (users.isEmpty()) {
+            throw new NotFoundException("User not found");
+        }
+
+        User user = users.get(0);
+        populateFriendships(List.of(user));
+        return user;
+    }
+
+    @Override
+    @Transactional
+    public void delete(Long id) {
+        jdbcTemplate.update("DELETE FROM users WHERE user_id = ?", id);
+    }
+
+    private User mapRowToUser(ResultSet rs, int rowNum) throws SQLException {
+        User user = new User();
+        user.setId(rs.getLong("user_id"));
+        user.setEmail(rs.getString("email"));
+        user.setLogin(rs.getString("login"));
+        user.setName(rs.getString("name"));
+        Date birthday = rs.getDate("birthday");
+        if (birthday != null) {
+            user.setBirthday(birthday.toLocalDate());
+        }
+        return user;
+    }
+
+    private void populateFriendships(Collection<User> users) {
+        if (users.isEmpty()) {
+            return;
+        }
+
+        Map<Long, User> usersById = users.stream()
+                .collect(Collectors.toMap(User::getId, Function.identity()));
+
+        users.forEach(user -> user.getFriends().clear());
+
+        List<Long> ids = usersById.keySet().stream().toList();
+
+        String placeholders = ids.stream()
+                .map(id -> "?")
+                .collect(Collectors.joining(","));
+
+        jdbcTemplate.query(
+                "SELECT user_id, friend_id FROM friendships WHERE user_id IN (" + placeholders + ")",
+                ids.toArray(),
+                rs -> {
+                    long userId = rs.getLong("user_id");
+                    long friendId = rs.getLong("friend_id");
+                    User user = usersById.get(userId);
+                    if (user != null) {
+                        user.getFriends().add(friendId);
+                    }
+                }
+        );
+    }
+
+    private void updateFriendships(User user) {
+        jdbcTemplate.update("DELETE FROM friendships WHERE user_id = ?", user.getId());
+
+        Set<Long> friends = user.getFriends();
+        if (friends == null || friends.isEmpty()) {
+            return;
+        }
+
+        List<Object[]> batchArgs = friends.stream()
+                .map(friendId -> new Object[]{user.getId(), friendId})
+                .toList();
+
+        jdbcTemplate.batchUpdate(
+                "INSERT INTO friendships (user_id, friend_id) VALUES (?, ?)",
+                batchArgs
+        );
+    }
+
+    private Date toSqlDate(LocalDate date) {
+        return date == null ? null : Date.valueOf(date);
+    }
+}


### PR DESCRIPTION
## Summary
- add a JDBC-backed `UserDbStorage` that persists users and their friendships
- add a JDBC-backed `FilmDbStorage` that maps MPA ratings, genres, and likes through JDBC queries

## Testing
- `mvn -q test` *(fails: unable to resolve Spring Boot parent POM from Maven Central due to HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_690904a39074832e9969bb659191f2b7